### PR TITLE
Message users on PR close

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Slackin'!
+# Git Slackin'
 
 Get notified better when using Github Pull Requests and Slack.
 
@@ -29,7 +29,7 @@ Features and commands listed below
   * Notifies the requested reviewers via a DM with a link to the PR
     * This happens if someone uses the Github UI to request a review as well.
   * Notifies the PR Opener who has been requested
-* Get notified when your PR is reviewd
+* Get notified when your PR is reviewed
   * Git-Slackin will message the opener of the PR informing them of who submitted a review, and in what state (approved, commented, requested changes)
 * Don't bother people when then are not requestable
 * Allow users to change their requestability
@@ -42,27 +42,32 @@ _Note_ All commands are case insensitive
 ### Everyone Commands
 
 Get Command List
+
 * Say `help`
-* Lists the commands 
+* Lists the commands
 
 Bench Yourself
+
 * Say `stop`, `silence`, or `mute`
 * This means you will not be requested or messaged by Git Slackin'
 
 Activate Notifications
+
 * Say `start`, or `notify`
 
 Am I requestable?
+
 * Say `status`
 * Get your github and slack usernames and your requestability status
 
 ### Admin/Manager commands
 
 What's everyone's state?
+
 * Say `overview`
 * Lists benched and available users, like the boot message
 
 Shut it all down
+
 * Say `shutdown`
 * Exits the git slackin' process.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1523,12 +1523,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1543,17 +1545,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1670,7 +1675,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1682,6 +1688,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1696,6 +1703,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1703,12 +1711,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1727,6 +1737,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1807,7 +1818,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1819,6 +1831,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1940,6 +1953,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/lib/github/webhookHandlers.js
+++ b/src/lib/github/webhookHandlers.js
@@ -320,10 +320,10 @@ async function prClosed(body) {
     const opener = await findByGithubName(body.pull_request.user.login);
 
     // From https://developer.github.com/v3/activity/events/types/#pullrequestevent action key
-    if (opener && body.pull_request.merged) {
-      await notifyOpenerPRClosed(opener, body.pull_request, true);
+    if (opener) {
+      await notifyOpenerPRClosed(opener, body.pull_request, body.pull_request.merged);
     } else {
-      await notifyOpenerPRClosed(opener, body.pull_request, false);
+      return logger.warn('[PR Closed] No slack user to message');
     }
     return logger.info(`[PR Closed] Opener: ${opener} notified`);
   } catch (e) {

--- a/src/lib/github/webhookHandlers.js
+++ b/src/lib/github/webhookHandlers.js
@@ -325,7 +325,7 @@ async function prClosed(body) {
     } else {
       return logger.warn('[PR Closed] No slack user to message');
     }
-    return logger.info(`[PR Closed] Opener: ${opener} notified`);
+    return logger.info(`[PR Closed] PR Opener notified`);
   } catch (e) {
     logger.error(`[PR Closed] Error: ${e}`);
     throw e;

--- a/src/lib/github/webhookRouter.js
+++ b/src/lib/github/webhookRouter.js
@@ -38,6 +38,7 @@ async function routeIt(body, { signature }) {
 
   try {
     if (body.action === 'opened') return await pr.opened(body);
+    if (body.action === 'closed') return await pr.closed(body);
     if (body.action === 'submitted') return await pr.reviewed(body);
     if (body.action === 'review_requested') return await pr.reviewRequested(body);
     if (body.action === 'synchronize') return await pr.sync(body);

--- a/src/server.js
+++ b/src/server.js
@@ -22,7 +22,7 @@ if (config.get('slack_manager_id')) {
   logger.warn('[BOOT] No admin user listed for bootup message.');
 }
 // silent just means it won't announce it to the entire team every time.
-if (process.env.GS_SILENT || config.get('silent_boot') === true) {
+if (process.env.GS_SILENT || (config.has('silent_boot') && config.get('silent_boot') === true)) {
   logger.info('[BOOT] Silent.');
 } else {
   logger.info('[BOOT] Starting up...');


### PR DESCRIPTION
When a `closed` action is handled, send the PR open a message saying it was either merged, or just regularly closed. 

Tested locally with my own slack app