### PR TITLE
Issue/25 restrict requestable users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features and commands listed below
   * Base it off of `config/example.json`
 * Create a `user_list.json` with all the users you want involved
   * Base it off of `example_user_list.json`
+  * Ensure that any repositories registered are cased appropriately, they are case sensitive
   * _Note:_ future goal is for this to live in a DB and for users to sign themselves up
 * Run service `npm start`
   * If running on a local machine use `ngrok` to make endpoint available to the internet

--- a/example_user_list.json
+++ b/example_user_list.json
@@ -6,6 +6,13 @@
     "slack": {
       "name": "james.firth",
       "id": "UZZZZZZZZ"
+    },
+    "repositories": {
+      "user-name/repository": {
+        "requestable": true,
+        "merger": false,
+        "notifications": true
+      }
     }
   }
 ]

--- a/src/lib/github/webhookHandlers.js
+++ b/src/lib/github/webhookHandlers.js
@@ -4,7 +4,7 @@ const shortid = require('shortid');
 
 // My Modules
 const logger = require('../../logger');
-const { selectRandomGithubUsersNot, findByGithubName, filterUsers } = require('../users');
+const { selectRandomGithubUsers, findByGithubName, filterUsers } = require('../users');
 const { send } = require('../slack/message');
 
 // Number of reviewers required for our workflow. Could move to config eventually.
@@ -136,7 +136,7 @@ async function prOpened(body) {
       return findByGithubName(user.login, logId);
     }));
     const notTheseUsers = opener ? preselectedUsers.concat(opener.github) : preselectedUsers;
-    const randomUsers = await selectRandomGithubUsersNot(notTheseUsers, numReviewersToRandomlySelect);
+    const randomUsers = await selectRandomGithubUsers(notTheseUsers, numReviewersToRandomlySelect);
     const users = preselectedUsers.concat(randomUsers);
 
     // TODO: Handle it better if either fails

--- a/src/lib/github/webhookHandlers.js
+++ b/src/lib/github/webhookHandlers.js
@@ -79,7 +79,7 @@ async function requestReviewersAndAssignees(users, body) {
   try {
     const githubUsers = users.map(user => user.github);
 
-    // Should probably look at the results to check if reviewres are there.
+    // Should probably look at the results to check if reviewers are there.
     const reviewRequests = await octokit.pullRequests.createReviewRequest({
       owner: body.pull_request.base.repo.owner.login,
       repo: body.pull_request.base.repo.name,

--- a/src/lib/github/webhookHandlers.js
+++ b/src/lib/github/webhookHandlers.js
@@ -136,7 +136,7 @@ async function prOpened(body) {
       return findByGithubName(user.login, logId);
     }));
     const notTheseUsers = opener ? preselectedUsers.concat(opener.github) : preselectedUsers;
-    const randomUsers = await selectRandomGithubUsers(notTheseUsers, numReviewersToRandomlySelect);
+    const randomUsers = await selectRandomGithubUsers(notTheseUsers, body.repository.full_name, numReviewersToRandomlySelect);
     const users = preselectedUsers.concat(randomUsers);
 
     // TODO: Handle it better if either fails

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -9,7 +9,7 @@ async function synchronizeUserList() {
   return fs.writeFileSync(userListFilePath, JSON.stringify(users, null, 2), 'utf-8');
 }
 
-// Register new users with some sane defaults
+// Register new users with some same defaults
 async function createUser(
   name, slackInfo, githubUsername,
   { requestable = true, merger = false, review_action = 'respond', notifications = true } = {}
@@ -32,10 +32,10 @@ async function createUser(
   return await synchronizeUserList();
 }
 
-// Randomly select <numUsers> github users that are not <notMe>
-async function selectRandomGithubUsersNot(notMe, numUsers = 1) {
+// Randomly select <numUsers> github users that are not excluded
+async function selectRandomGithubUsers(excludedUsers, numUsers = 1) {
   const usersToReturn = [];
-  const excludedGithubNames = Array.isArray(notMe) ? notMe : [notMe];
+  const excludedGithubNames = Array.isArray(excludedUsers) ? excludedUsers : [excludedUsers];
 
   while (usersToReturn.length < numUsers) {
     // Select a random user that is not the one we passed based on github name
@@ -180,7 +180,7 @@ async function listAllUserNamesByAvailability() {
 
 module.exports = {
   createUser,
-  selectRandomGithubUsersNot,
+  selectRandomGithubUsers,
   findByGithubName,
   findBySlackUserId,
   filterUsers,

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -9,7 +9,7 @@ async function synchronizeUserList() {
   return fs.writeFileSync(userListFilePath, JSON.stringify(users, null, 2), 'utf-8');
 }
 
-// Register new users with some same defaults
+// Register new users with some sane defaults
 async function createUser(
   name, slackInfo, githubUsername,
   { requestable = true, merger = false, review_action = 'respond', notifications = true } = {}

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -40,7 +40,7 @@ async function selectRandomGithubUsers(excludedUsers, repository, numUsers = 1) 
   const availableUsers = users.filter(user => {
     let repositoryRequestable = false;
     if (repository in user.repositories) {
-      repositoryRequestable = repositoryRequestable = user.repositories[repository].requestable
+      repositoryRequestable = user.repositories[repository].requestable
     }
     return !excludedGithubNames.includes(user.github) && user.requestable && repositoryRequestable;
   });

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -35,8 +35,6 @@ async function createUser(
 // Randomly select <numUsers> github users that are not excluded
 async function selectRandomGithubUsers(excludedUsers, repository, numUsers = 1) {
   const excludedGithubNames = Array.isArray(excludedUsers) ? excludedUsers : [excludedUsers];
-  // Standardize repository name
-  repository = repository.toLowerCase()
 
   // Get all available users for this repository that are currently requestable
   const availableUsers = users.filter(user => {

--- a/src/server.js
+++ b/src/server.js
@@ -4,18 +4,18 @@ const http = require('http');
 const https = require('https'); // TODO: Use this to serve up HTTPS properly
 const fs = require('fs');
 const path = require('path');
-const port = 8778;
-const httpsPort = 8779;
 const bodyParser = require('body-parser');
 const config = require('config');
 const logger = require('./logger');
-// My modules
+
 const githubWebhooks = require('./lib/github/webhookRouter');
 const slackAction = require('./lib/slack/actionHandlers');
 const slackEventHandler = require('./lib/slack/eventHandlers');
 const slackCommon = require('./lib/slack/common');
 const { openDM } = require('./lib/slack/message');
-// Bootup message stuff
+
+const port = 8778;
+const httpsPort = 8779;
 
 // Handle errors (see `errorCodes` export)
 
@@ -49,8 +49,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 // Basic web server to handle payloads
 app.post('/payload', (req, res) => {
   if (req.headers['x-github-event'] === 'pull_request' ||
-  req.headers['x-github-event'] === 'pull_request_review' ||
-  req.headers['x-github-event'] === 'pull_request_review_comment') {
+    req.headers['x-github-event'] === 'pull_request_review' ||
+    req.headers['x-github-event'] === 'pull_request_review_comment') {
     return githubWebhooks.handle(req.body, {
       signature: req.headers['x-hub-signature'],
       webhookId: req.headers['x-github-delivery'],


### PR DESCRIPTION
This will enable differing repositories for users. 

While keys exist for notifications and merger, neither are used. Only `requestable` is consumed and used for selecting reviwers

Resolves #25